### PR TITLE
HGI-7208 - Remove address streams and build address into transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.vscode

--- a/tap_netsuite_rest/client.py
+++ b/tap_netsuite_rest/client.py
@@ -766,3 +766,4 @@ class TransactionRootStream(NetsuiteDynamicStream):
         row["shippingaddress"] = row.get("shippingaddress").replace("  ", " ") if row.get("shippingaddress") else None
         row["billingaddress"] = row.get("billingaddress").replace("  ", " ") if row.get("billingaddress") else None
         return row
+    

--- a/tap_netsuite_rest/client.py
+++ b/tap_netsuite_rest/client.py
@@ -759,3 +759,10 @@ class TransactionRootStream(NetsuiteDynamicStream):
         )
         self.logger.info(f"Making query ({timeframe})")
         return payload
+
+
+    # Remove double spaces that might result from empty address fields
+    def post_process(self, row: dict, context: Optional[dict] = None) -> Optional[dict]:
+        row["shippingaddress"] = row.get("shippingaddress").replace("  ", " ") if row.get("shippingaddress") else None
+        row["billingaddress"] = row.get("billingaddress").replace("  ", " ") if row.get("billingaddress") else None
+        return row

--- a/tap_netsuite_rest/client.py
+++ b/tap_netsuite_rest/client.py
@@ -5,6 +5,7 @@ import backoff
 import requests
 import pendulum
 import copy
+import re
 
 from pathlib import Path
 from datetime import datetime, timedelta
@@ -763,7 +764,12 @@ class TransactionRootStream(NetsuiteDynamicStream):
 
     # Remove double spaces that might result from empty address fields
     def post_process(self, row: dict, context: Optional[dict] = None) -> Optional[dict]:
-        row["shippingaddress"] = row.get("shippingaddress").replace("  ", " ") if row.get("shippingaddress") else None
-        row["billingaddress"] = row.get("billingaddress").replace("  ", " ") if row.get("billingaddress") else None
+        # Collapse duplicate spaces in address fields
+        if row.get("shippingaddress"):
+            row["shippingaddress"] = re.sub(r'(, )+', ', ', row["shippingaddress"]).strip(', ')
+        if row.get("billingaddress"):
+            row["billingaddress"] = re.sub(r'(, )+', ', ', row["billingaddress"]).strip(', ')
+        
+
         return row
     

--- a/tap_netsuite_rest/streams.py
+++ b/tap_netsuite_rest/streams.py
@@ -64,8 +64,8 @@ class SalesTransactionsStream(TransactionRootStream):
 
     select = """
         transaction.*
-        , COALESCE(tsa.addr1, '') || ', ' || COALESCE(tsa.addr2, '') || ', ' || COALESCE(tsa.addr3, '') || ', ' || COALESCE(tsa.city, '') || ', ' || COALESCE(tsa.state, '') || ', ' || COALESCE(tsa.country, '') || ', ' || COALESCE(tsa.zip, '') as shippingaddress
-        , COALESCE(tba.addr1, '') || ', ' || COALESCE(tba.addr2, '') || ', ' || COALESCE(tba.addr3, '') || ', ' || COALESCE(tba.city, '') || ', ' || COALESCE(tba.state, '') || ', ' || COALESCE(tba.country, '') || ', ' || COALESCE(tba.zip, '') as billingaddress
+        , COALESCE(tsa.addr1, '') || ', ' || COALESCE(tsa.addr2, '') || ', ' || COALESCE(tsa.addr3, '') || ', ' || COALESCE(tsa.city, '') || ', ' || COALESCE(tsa.state, '') || ', ' || COALESCE(tsa.zip, '') || ', ' || COALESCE(tsa.country, '') as shippingaddress
+        , COALESCE(tba.addr1, '') || ', ' || COALESCE(tba.addr2, '') || ', ' || COALESCE(tba.addr3, '') || ', ' || COALESCE(tba.city, '') || ', ' || COALESCE(tba.state, '') || ', ' || COALESCE(tba.zip, '') || ', ' || COALESCE(tba.country, '') as billingaddress
         """
 
     join = """
@@ -132,8 +132,8 @@ class VendorBillsStream(NetSuiteStream):
 
     select = """
         transaction.*
-        , COALESCE(tsa.addr1, '') || ', ' || COALESCE(tsa.addr2, '') || ', ' || COALESCE(tsa.addr3, '') || ', ' || COALESCE(tsa.city, '') || ', ' || COALESCE(tsa.state, '') || ', ' || COALESCE(tsa.country, '') || ', ' || COALESCE(tsa.zip, '') as shippingaddress
-        , COALESCE(tba.addr1, '') || ', ' || COALESCE(tba.addr2, '') || ', ' || COALESCE(tba.addr3, '') || ', ' || COALESCE(tba.city, '') || ', ' || COALESCE(tba.state, '') || ', ' || COALESCE(tba.country, '') || ', ' || COALESCE(tba.zip, '') as billingaddress
+        , COALESCE(tsa.addr1, '') || ', ' || COALESCE(tsa.addr2, '') || ', ' || COALESCE(tsa.addr3, '') || ', ' || COALESCE(tsa.city, '') || ', ' || COALESCE(tsa.state, '') || ', ' || COALESCE(tsa.zip, '') || ', ' || COALESCE(tsa.country, '') as shippingaddress
+        , COALESCE(tba.addr1, '') || ', ' || COALESCE(tba.addr2, '') || ', ' || COALESCE(tba.addr3, '') || ', ' || COALESCE(tba.city, '') || ', ' || COALESCE(tba.state, '') || ', ' || COALESCE(tba.zip, '') || ', ' || COALESCE(tba.country, '') as billingaddress
         """
 
     join = """
@@ -672,8 +672,8 @@ class TransactionsStream(TransactionRootStream):
     
     select = """
         transaction.*
-        , COALESCE(tsa.addr1, '') || ', ' || COALESCE(tsa.addr2, '') || ', ' || COALESCE(tsa.addr3, '') || ', ' || COALESCE(tsa.city, '') || ', ' || COALESCE(tsa.state, '') || ', ' || COALESCE(tsa.country, '') || ', ' || COALESCE(tsa.zip, '') as shippingaddress
-        , COALESCE(tba.addr1, '') || ', ' || COALESCE(tba.addr2, '') || ', ' || COALESCE(tba.addr3, '') || ', ' || COALESCE(tba.city, '') || ', ' || COALESCE(tba.state, '') || ', ' || COALESCE(tba.country, '') || ', ' || COALESCE(tba.zip, '') as billingaddress
+        , COALESCE(tsa.addr1, '') || ', ' || COALESCE(tsa.addr2, '') || ', ' || COALESCE(tsa.addr3, '') || ', ' || COALESCE(tsa.city, '') || ', ' || COALESCE(tsa.state, '') || ', ' || COALESCE(tsa.zip, '') || ', ' || COALESCE(tsa.country, '') as shippingaddress
+        , COALESCE(tba.addr1, '') || ', ' || COALESCE(tba.addr2, '') || ', ' || COALESCE(tba.addr3, '') || ', ' || COALESCE(tba.city, '') || ', ' || COALESCE(tba.state, '') || ', ' || COALESCE(tba.zip, '') || ', ' || COALESCE(tba.country, '') as billingaddress
         """
 
     join = """

--- a/tap_netsuite_rest/streams.py
+++ b/tap_netsuite_rest/streams.py
@@ -64,8 +64,8 @@ class SalesTransactionsStream(TransactionRootStream):
 
     select = """
         transaction.*
-        , COALESCE(tsa.addr1, '') || ' ' || COALESCE(tsa.addr2, '') || ' ' || COALESCE(tsa.addr3, '') || ' ' || COALESCE(tsa.city, '') || ' ' || COALESCE(tsa.state, '') || ' ' || COALESCE(tsa.country, '') || ' ' || COALESCE(tsa.zip, '') as shippingaddress
-        , COALESCE(tba.addr1, '') || ' ' || COALESCE(tba.addr2, '') || ' ' || COALESCE(tba.addr3, '') || ' ' || COALESCE(tba.city, '') || ' ' || COALESCE(tba.state, '') || ' ' || COALESCE(tba.country, '') || ' ' || COALESCE(tba.zip, '') as billingaddress
+        , COALESCE(tsa.addr1, '') || ', ' || COALESCE(tsa.addr2, '') || ', ' || COALESCE(tsa.addr3, '') || ', ' || COALESCE(tsa.city, '') || ', ' || COALESCE(tsa.state, '') || ', ' || COALESCE(tsa.country, '') || ', ' || COALESCE(tsa.zip, '') as shippingaddress
+        , COALESCE(tba.addr1, '') || ', ' || COALESCE(tba.addr2, '') || ', ' || COALESCE(tba.addr3, '') || ', ' || COALESCE(tba.city, '') || ', ' || COALESCE(tba.state, '') || ', ' || COALESCE(tba.country, '') || ', ' || COALESCE(tba.zip, '') as billingaddress
         """
 
     join = """
@@ -132,8 +132,8 @@ class VendorBillsStream(NetSuiteStream):
 
     select = """
         transaction.*
-        , COALESCE(tsa.addr1, '') || ' ' || COALESCE(tsa.addr2, '') || ' ' || COALESCE(tsa.addr3, '') || ' ' || COALESCE(tsa.city, '') || ' ' || COALESCE(tsa.state, '') || ' ' || COALESCE(tsa.country, '') || ' ' || COALESCE(tsa.zip, '') as shippingaddress
-        , COALESCE(tba.addr1, '') || ' ' || COALESCE(tba.addr2, '') || ' ' || COALESCE(tba.addr3, '') || ' ' || COALESCE(tba.city, '') || ' ' || COALESCE(tba.state, '') || ' ' || COALESCE(tba.country, '') || ' ' || COALESCE(tba.zip, '') as billingaddress
+        , COALESCE(tsa.addr1, '') || ', ' || COALESCE(tsa.addr2, '') || ', ' || COALESCE(tsa.addr3, '') || ', ' || COALESCE(tsa.city, '') || ', ' || COALESCE(tsa.state, '') || ', ' || COALESCE(tsa.country, '') || ', ' || COALESCE(tsa.zip, '') as shippingaddress
+        , COALESCE(tba.addr1, '') || ', ' || COALESCE(tba.addr2, '') || ', ' || COALESCE(tba.addr3, '') || ', ' || COALESCE(tba.city, '') || ', ' || COALESCE(tba.state, '') || ', ' || COALESCE(tba.country, '') || ', ' || COALESCE(tba.zip, '') as billingaddress
         """
 
     join = """
@@ -672,8 +672,8 @@ class TransactionsStream(TransactionRootStream):
     
     select = """
         transaction.*
-        , COALESCE(tsa.addr1, '') || ' ' || COALESCE(tsa.addr2, '') || ' ' || COALESCE(tsa.addr3, '') || ' ' || COALESCE(tsa.city, '') || ' ' || COALESCE(tsa.state, '') || ' ' || COALESCE(tsa.country, '') || ' ' || COALESCE(tsa.zip, '') as shippingaddress
-        , COALESCE(tba.addr1, '') || ' ' || COALESCE(tba.addr2, '') || ' ' || COALESCE(tba.addr3, '') || ' ' || COALESCE(tba.city, '') || ' ' || COALESCE(tba.state, '') || ' ' || COALESCE(tba.country, '') || ' ' || COALESCE(tba.zip, '') as billingaddress
+        , COALESCE(tsa.addr1, '') || ', ' || COALESCE(tsa.addr2, '') || ', ' || COALESCE(tsa.addr3, '') || ', ' || COALESCE(tsa.city, '') || ', ' || COALESCE(tsa.state, '') || ', ' || COALESCE(tsa.country, '') || ', ' || COALESCE(tsa.zip, '') as shippingaddress
+        , COALESCE(tba.addr1, '') || ', ' || COALESCE(tba.addr2, '') || ', ' || COALESCE(tba.addr3, '') || ', ' || COALESCE(tba.city, '') || ', ' || COALESCE(tba.state, '') || ', ' || COALESCE(tba.country, '') || ', ' || COALESCE(tba.zip, '') as billingaddress
         """
 
     join = """

--- a/tap_netsuite_rest/streams.py
+++ b/tap_netsuite_rest/streams.py
@@ -61,6 +61,18 @@ class SalesTransactionsStream(TransactionRootStream):
     replication_key = "lastmodifieddate"
     custom_filter = "transaction.recordtype = 'salesorder'"
 
+
+    select = """
+        transaction.*
+        , COALESCE(tsa.addr1, '') || ' ' || COALESCE(tsa.addr2, '') || ' ' || COALESCE(tsa.addr3, '') || ' ' || COALESCE(tsa.city, '') || ' ' || COALESCE(tsa.state, '') || ' ' || COALESCE(tsa.country, '') || ' ' || COALESCE(tsa.zip, '') as shippingaddress
+        , COALESCE(tba.addr1, '') || ' ' || COALESCE(tba.addr2, '') || ' ' || COALESCE(tba.addr3, '') || ' ' || COALESCE(tba.city, '') || ' ' || COALESCE(tba.state, '') || ' ' || COALESCE(tba.country, '') || ' ' || COALESCE(tba.zip, '') as billingaddress
+        """
+
+    join = """
+        LEFT JOIN TransactionShippingAddress tsa ON transaction.shippingaddress = tsa.nkey
+        LEFT JOIN TransactionBillingAddress tba ON transaction.billingaddress = tba.nkey
+    """
+
     schema = th.PropertiesList(
         th.Property("abbrevtype", th.StringType),
         th.Property("actualshipdate", th.DateTimeType),
@@ -117,11 +129,25 @@ class VendorBillsStream(NetSuiteStream):
     replication_key = "lastmodifieddate"
     custom_filter = "recordtype = 'vendorbill'"
 
+
+    select = """
+        transaction.*
+        , COALESCE(tsa.addr1, '') || ' ' || COALESCE(tsa.addr2, '') || ' ' || COALESCE(tsa.addr3, '') || ' ' || COALESCE(tsa.city, '') || ' ' || COALESCE(tsa.state, '') || ' ' || COALESCE(tsa.country, '') || ' ' || COALESCE(tsa.zip, '') as shippingaddress
+        , COALESCE(tba.addr1, '') || ' ' || COALESCE(tba.addr2, '') || ' ' || COALESCE(tba.addr3, '') || ' ' || COALESCE(tba.city, '') || ' ' || COALESCE(tba.state, '') || ' ' || COALESCE(tba.country, '') || ' ' || COALESCE(tba.zip, '') as billingaddress
+        """
+
+    join = """
+        LEFT JOIN TransactionShippingAddress tsa ON transaction.shippingaddress = tsa.nkey
+        LEFT JOIN TransactionBillingAddress tba ON transaction.billingaddress = tba.nkey
+    """
+
     schema = th.PropertiesList(
         th.Property("abbrevtype", th.StringType),
         th.Property("approvalstatus", th.StringType),
         th.Property("balsegstatus", th.StringType),
         th.Property("billingstatus", th.StringType),
+        th.Property("billingaddress", th.StringType),
+        th.Property("shippingaddress", th.StringType),
         th.Property("closedate", th.DateTimeType),
         th.Property("createdby", th.StringType),
         th.Property("createddate", th.DateTimeType),
@@ -284,18 +310,20 @@ class VendorStream(NetsuiteDynamicStream):
     replication_key = "lastmodifieddate"
 
 
-class ShippingAddressStream(NetsuiteDynamicStream):
-    name = "shipping_address"
-    primary_keys = ["nkey"]
-    table = "TransactionShippingAddress"
-    replication_key = "lastmodifieddate"
+# The following streams were removed because they are not documented by Netsuite nor well behaved with keys:
+# Instead, shipping + billing address is joined on transaction streams
+# class ShippingAddressStream(NetsuiteDynamicStream):
+#     name = "shipping_address"
+#     primary_keys = ["nkey"]
+#     table = "TransactionShippingAddress"
+#     replication_key = "lastmodifieddate"
 
 
-class BillingAddressStream(NetsuiteDynamicStream):
-    name = "billing_address"
-    primary_keys = ["nkey"]
-    table = "TransactionBillingAddress"
-    replication_key = "lastmodifieddate"
+# class BillingAddressStream(NetsuiteDynamicStream):
+#     name = "billing_address"
+#     primary_keys = ["nkey"]
+#     table = "TransactionBillingAddress"
+#     replication_key = "lastmodifieddate"
 
 
 class TermStream(NetsuiteDynamicStream):
@@ -640,10 +668,25 @@ class TransactionsStream(TransactionRootStream):
     primary_keys = ["id", "lastmodifieddate"]
     table = "transaction"
     replication_key = "lastmodifieddate"
+
+    
+    select = """
+        transaction.*
+        , COALESCE(tsa.addr1, '') || ' ' || COALESCE(tsa.addr2, '') || ' ' || COALESCE(tsa.addr3, '') || ' ' || COALESCE(tsa.city, '') || ' ' || COALESCE(tsa.state, '') || ' ' || COALESCE(tsa.country, '') || ' ' || COALESCE(tsa.zip, '') as shippingaddress
+        , COALESCE(tba.addr1, '') || ' ' || COALESCE(tba.addr2, '') || ' ' || COALESCE(tba.addr3, '') || ' ' || COALESCE(tba.city, '') || ' ' || COALESCE(tba.state, '') || ' ' || COALESCE(tba.country, '') || ' ' || COALESCE(tba.zip, '') as billingaddress
+        """
+
+    join = """
+        LEFT JOIN TransactionShippingAddress tsa ON transaction.shippingaddress = tsa.nkey
+        LEFT JOIN TransactionBillingAddress tba ON transaction.billingaddress = tba.nkey
+    """
+    
     default_fields = [
         th.Property("id", th.StringType),
         th.Property("type", th.StringType),
         th.Property("entity", th.StringType),
+        th.Property("shippingaddress", th.StringType),
+        th.Property("billingaddress", th.StringType),
         th.Property("otherrefnum", th.StringType),
         th.Property("closedate", th.DateType),
         th.Property("duedate", th.DateType),


### PR DESCRIPTION
This PR:
- Comments out the `shippingaddress` and `billingaddress` streams because they are poorly documented and lack well defined replication keys
- Adds logic to Transactions (And filtered transaction streams) to join with the address tables to support wellformed `shippingaddress` and `billingaddress` fields