### PR TITLE
fix(HGI-8752): fix pagination error

### DIFF
--- a/tap_netsuite_rest/streams.py
+++ b/tap_netsuite_rest/streams.py
@@ -676,7 +676,8 @@ class ProfitLossReportStream(NetSuiteStream):
             return offset
 
         totalResults = next(extract_jsonpath("$.totalResults", response.json()))
-        if offset > totalResults:
+
+        if offset >= totalResults:
             self.query_date = (parse(self.end_date) + timedelta(1)).replace(tzinfo=None)
             report_end_date = parse(self.config.get("report_end_date")).replace(tzinfo=None) if self.config.get("report_end_date") else None
             end_date = report_end_date or datetime.utcnow()


### PR DESCRIPTION
fixes a bug in the pagination where if in the end of a pagination for a given period the number of results was exactly as the page size we would stop fetching data instead of jumping to the next period