### PR TITLE
HGI-10227: Handle bad account id fail on InvalidCredentialsError instead of ConnectionError

### DIFF
--- a/tap_netsuite_rest/client.py
+++ b/tap_netsuite_rest/client.py
@@ -636,6 +636,35 @@ class NetsuiteDynamicSchema(NetSuiteStream):
         self.integer_fields = []
         return super().__init__(*args, **kwargs)
 
+    @staticmethod
+    def _check_netsuite_dns_failure(e):
+        """Walk the exception chain to detect if a ConnectionError is caused by
+        a NameResolutionError targeting the NetSuite suitetalk domain, which
+        indicates an invalid account ID rather than a transient network issue.
+        Raises InvalidCredentialsError if so."""
+        # requests raises `ConnectionError(e, request=request)` without `from e`,
+        # so __cause__ is None — the wrapped exception is only in __context__.
+        # We walk both __cause__ and __context__ to find NameResolutionError.
+        seen = set()
+        queue = [e]
+        while queue:
+            current = queue.pop(0)
+            if id(current) in seen:
+                continue
+            seen.add(id(current))
+            if type(current).__name__ == "NameResolutionError":
+                failed_host = getattr(current, "_host", "") or ""
+                if "suitetalk.api.netsuite.com" in failed_host:
+                    raise InvalidCredentialsError(
+                        f"Please verify your account ID is correct. "
+                        f"Error: {str(e)}"
+                    ) from e
+                return
+            if getattr(current, "__cause__", None) is not None:
+                queue.append(current.__cause__)
+            if getattr(current, "__context__", None) is not None:
+                queue.append(current.__context__)
+
     @backoff.on_exception(backoff.expo, (
         HTTPError,
         RetriableAPIError,
@@ -679,11 +708,7 @@ class NetsuiteDynamicSchema(NetSuiteStream):
             response.raise_for_status()
             self.schema_response = response.json()
         except requests.exceptions.ConnectionError as e:
-            if "NameResolutionError" in str(e) or "Failed to resolve" in str(e) or "nodename nor servname" in str(e):
-                raise InvalidCredentialsError(
-                    f"Please verify your account ID is correct. "
-                    f"Error: {str(e)}"
-                ) from e
+            self._check_netsuite_dns_failure(e)
             pass
 
         except:
@@ -715,7 +740,11 @@ class NetsuiteDynamicSchema(NetSuiteStream):
                         }
                     )
                 )
-                response = s.send(prepared_req, timeout=self.timeout)
+                try:
+                    response = s.send(prepared_req, timeout=self.timeout)
+                except requests.exceptions.ConnectionError as e:
+                    self._check_netsuite_dns_failure(e)
+                    raise
                 self.logger.debug(
                     "get_schema(%s): customfield suiteql done offset=%s status=%s",
                     self.name,
@@ -755,7 +784,11 @@ class NetsuiteDynamicSchema(NetSuiteStream):
                 url,
             )
 
-            response = s.send(prepared_req, timeout=self.timeout)
+            try:
+                response = s.send(prepared_req, timeout=self.timeout)
+            except requests.exceptions.ConnectionError as e:
+                self._check_netsuite_dns_failure(e)
+                raise
             self.logger.debug(
                 "get_schema(%s): suiteql schema inference POST done status=%s",
                 self.name,

--- a/tap_netsuite_rest/client.py
+++ b/tap_netsuite_rest/client.py
@@ -678,6 +678,14 @@ class NetsuiteDynamicSchema(NetSuiteStream):
             )
             response.raise_for_status()
             self.schema_response = response.json()
+        except requests.exceptions.ConnectionError as e:
+            if "NameResolutionError" in str(e) or "Failed to resolve" in str(e) or "nodename nor servname" in str(e):
+                raise InvalidCredentialsError(
+                    f"Please verify your account ID is correct. "
+                    f"Error: {str(e)}"
+                ) from e
+            pass
+
         except:
             pass
         

--- a/tap_netsuite_rest/client.py
+++ b/tap_netsuite_rest/client.py
@@ -683,7 +683,7 @@ class NetsuiteDynamicSchema(NetSuiteStream):
         except requests.exceptions.ConnectionError as e:
             if not self._tap.dns_checked:
                 check_netsuite_dns_failure(e)
-            raise
+            pass
 
         except:
             pass

--- a/tap_netsuite_rest/client.py
+++ b/tap_netsuite_rest/client.py
@@ -33,6 +33,7 @@ from hotglue_singer_sdk.exceptions import InvalidStreamSortException
 import singer
 from singer import StateMessage
 from hotglue_etl_exceptions import InvalidCredentialsError
+from tap_netsuite_rest.utils import check_netsuite_dns_failure
 
 
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
@@ -636,34 +637,13 @@ class NetsuiteDynamicSchema(NetSuiteStream):
         self.integer_fields = []
         return super().__init__(*args, **kwargs)
 
-    @staticmethod
-    def _check_netsuite_dns_failure(e):
-        """Walk the exception chain to detect if a ConnectionError is caused by
-        a NameResolutionError targeting the NetSuite suitetalk domain, which
-        indicates an invalid account ID rather than a transient network issue.
-        Raises InvalidCredentialsError if so."""
-        # requests raises `ConnectionError(e, request=request)` without `from e`,
-        # so __cause__ is None — the wrapped exception is only in __context__.
-        # We walk both __cause__ and __context__ to find NameResolutionError.
-        seen = set()
-        queue = [e]
-        while queue:
-            current = queue.pop(0)
-            if id(current) in seen:
-                continue
-            seen.add(id(current))
-            if type(current).__name__ == "NameResolutionError":
-                failed_host = getattr(current, "_host", "") or ""
-                if "suitetalk.api.netsuite.com" in failed_host:
-                    raise InvalidCredentialsError(
-                        f"Please verify your account ID is correct. "
-                        f"Error: {str(e)}"
-                    ) from e
-                return
-            if getattr(current, "__cause__", None) is not None:
-                queue.append(current.__cause__)
-            if getattr(current, "__context__", None) is not None:
-                queue.append(current.__context__)
+    def get_schema(self):
+        try:
+            self._get_schema()
+        except requests.exceptions.ConnectionError as e:
+            if not self._tap.dns_checked:
+                check_netsuite_dns_failure(e)
+            raise
 
     @backoff.on_exception(backoff.expo, (
         HTTPError,
@@ -672,7 +652,7 @@ class NetsuiteDynamicSchema(NetSuiteStream):
         requests.exceptions.ConnectionError,
         RemoteDisconnected,
     ), max_tries=5, factor=2)
-    def get_schema(self): # noqa: C901
+    def _get_schema(self): 
         s = self.get_session()
         self.logger.debug(
             "get_schema(%s) start table=%s use_dynamic_fields=%s",
@@ -700,6 +680,7 @@ class NetsuiteDynamicSchema(NetSuiteStream):
             prepared_req.headers.update({"Accept": "application/schema+json"})
             self.logger.debug("get_schema(%s): metadata-catalog GET send", self.name)
             response = s.send(prepared_req, timeout=self.timeout)
+            self._tap.dns_checked = True
             self.logger.debug(
                 "get_schema(%s): metadata-catalog GET done status=%s",
                 self.name,
@@ -707,9 +688,8 @@ class NetsuiteDynamicSchema(NetSuiteStream):
             )
             response.raise_for_status()
             self.schema_response = response.json()
-        except requests.exceptions.ConnectionError as e:
-            self._check_netsuite_dns_failure(e)
-            pass
+        except requests.exceptions.ConnectionError:
+            raise
 
         except:
             pass
@@ -740,11 +720,7 @@ class NetsuiteDynamicSchema(NetSuiteStream):
                         }
                     )
                 )
-                try:
-                    response = s.send(prepared_req, timeout=self.timeout)
-                except requests.exceptions.ConnectionError as e:
-                    self._check_netsuite_dns_failure(e)
-                    raise
+                response = s.send(prepared_req, timeout=self.timeout)
                 self.logger.debug(
                     "get_schema(%s): customfield suiteql done offset=%s status=%s",
                     self.name,
@@ -784,11 +760,7 @@ class NetsuiteDynamicSchema(NetSuiteStream):
                 url,
             )
 
-            try:
-                response = s.send(prepared_req, timeout=self.timeout)
-            except requests.exceptions.ConnectionError as e:
-                self._check_netsuite_dns_failure(e)
-                raise
+            response = s.send(prepared_req, timeout=self.timeout)
             self.logger.debug(
                 "get_schema(%s): suiteql schema inference POST done status=%s",
                 self.name,

--- a/tap_netsuite_rest/client.py
+++ b/tap_netsuite_rest/client.py
@@ -637,14 +637,6 @@ class NetsuiteDynamicSchema(NetSuiteStream):
         self.integer_fields = []
         return super().__init__(*args, **kwargs)
 
-    def get_schema(self):
-        try:
-            self._get_schema()
-        except requests.exceptions.ConnectionError as e:
-            if not self._tap.dns_checked:
-                check_netsuite_dns_failure(e)
-            raise
-
     @backoff.on_exception(backoff.expo, (
         HTTPError,
         RetriableAPIError,
@@ -652,7 +644,7 @@ class NetsuiteDynamicSchema(NetSuiteStream):
         requests.exceptions.ConnectionError,
         RemoteDisconnected,
     ), max_tries=5, factor=2)
-    def _get_schema(self): 
+    def get_schema(self): # noqa: C901
         s = self.get_session()
         self.logger.debug(
             "get_schema(%s) start table=%s use_dynamic_fields=%s",
@@ -688,7 +680,9 @@ class NetsuiteDynamicSchema(NetSuiteStream):
             )
             response.raise_for_status()
             self.schema_response = response.json()
-        except requests.exceptions.ConnectionError:
+        except requests.exceptions.ConnectionError as e:
+            if not self._tap.dns_checked:
+                check_netsuite_dns_failure(e)
             raise
 
         except:

--- a/tap_netsuite_rest/tap.py
+++ b/tap_netsuite_rest/tap.py
@@ -54,6 +54,7 @@ class TapNetSuite(Tap):
 
     name = "tap-netsuite-rest"
     custom_fields = None
+    dns_checked = False
     alerting_level = AlertingLevel.ERROR
 
     config_jsonschema = th.PropertiesList(

--- a/tap_netsuite_rest/utils.py
+++ b/tap_netsuite_rest/utils.py
@@ -1,0 +1,39 @@
+import socket
+from hotglue_etl_exceptions import InvalidCredentialsError
+
+_NETSUITE_CONTROL_HOST = "netsuite.com"
+
+def check_netsuite_dns_failure(e):
+    if not _is_netsuite_subdomain_dns_failure(e):
+        return
+    if not _control_host_resolves():
+        return
+    raise InvalidCredentialsError(
+        f"Please verify your account ID is correct. Error: {str(e)}"
+    ) from e
+
+
+def _is_netsuite_subdomain_dns_failure(e):
+    seen = set()
+    queue = [e]
+    while queue:
+        current = queue.pop(0)
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        if type(current).__name__ == "NameResolutionError":
+            failed_host = getattr(current, "_host", "") or ""
+            return "suitetalk.api.netsuite.com" in failed_host
+        if getattr(current, "__cause__", None) is not None:
+            queue.append(current.__cause__)
+        if getattr(current, "__context__", None) is not None:
+            queue.append(current.__context__)
+    return False
+
+
+def _control_host_resolves():
+    try:
+        socket.gethostbyname(_NETSUITE_CONTROL_HOST)
+        return True
+    except OSError:
+        return False


### PR DESCRIPTION
Added a specific except requests.exceptions.ConnectionError block inside get_schema() that checks whether the error is caused by a DNS resolution failure. If so, it immediately raises InvalidCredentialsError with a clear message pointing the user to verify their account ID